### PR TITLE
Collaborators list: Pagination issues

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -89,9 +89,17 @@ def git(command, *args, **kwargs):
     return True
 
 def get_authorised_users(config):
-    resp = requests.get("https://api.github.com/repos/%s/%s/collaborators?per_page=200" % (config["org_name"], config["repo_name"]),
-                        auth=(config["username"], config["password"]))
-    return set(item["login"] for item in resp.json())
+    page = 1
+    count = 100
+    result = set()
+    while count == 100:
+        resp = requests.get("https://api.github.com/repos/%s/%s/collaborators?per_page=100&page=%s" % (config["org_name"], config["repo_name"], page),
+                            auth=(config["username"], config["password"]))
+        json = resp.json()
+        result = result.union(set(item["login"] for item in json))
+        count = len(json)
+        page += 1
+    return result
 
 def process_pull_request(config, data, user_is_authorised):
     base_path = config["base_path"]


### PR DESCRIPTION
/repos/w3c/web-platform-tests/collaborators only shows 30 collaborators because of the pagination
https://developer.github.com/v3/#pagination
updating the uri to show 200 users
