### PR TITLE
Replace requests.get(…).json() with json.loads(…)

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -95,7 +95,10 @@ def get_authorised_users(config):
     for i in itertools.count(1):
         resp = requests.get("https://api.github.com/repos/%s/%s/collaborators?per_page=100&page=%s" % (config["org_name"], config["repo_name"], i),
                             auth=(config["username"], config["password"]))
-        data = json.loads(resp.text)
+        try:
+            data = resp.json()
+        except TypeError:
+            data = resp.json
         result |= set(item["login"] for item in data)
         if len(data) < 100:
             break

--- a/sync.py
+++ b/sync.py
@@ -95,7 +95,7 @@ def get_authorised_users(config):
     for i in itertools.count(1):
         resp = requests.get("https://api.github.com/repos/%s/%s/collaborators?per_page=100&page=%s" % (config["org_name"], config["repo_name"], i),
                             auth=(config["username"], config["password"]))
-        data = resp.json()
+        data = json.loads(resp.text)
         result |= set(item["login"] for item in data)
         if len(data) < 100:
             break


### PR DESCRIPTION
In the server environment on w3c-test.org, calling .json() on the result of
from a requests.get(…) fails with a `'list' object is not callable` error.
I think it might be a bug in the version of the Python "requests" module we
have on w3c-test.org but I don't really know. But calling .text on the
result works fine, so we can just use json.loads(requests.get(…).text)
instead and achieve the same effect. So let's just do that.