### PR TITLE
switch to using RawConfigParser

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -262,7 +262,7 @@ def register_events(config):
     print >> sys.stderr, "%i\n%s" % (resp.status_code, resp.text)
 
 def get_config():
-    config = ConfigParser.SafeConfigParser()
+    config = ConfigParser.RawConfigParser()
     config.read(os.path.abspath(os.path.expanduser(config_path)))
     rv = dict(config.items("sync"))
     if not "base_path" in rv:


### PR DESCRIPTION
The config file does not require interpolation. Switching to RawConfigParser allows values (such as github password) to include symbols (such as `%`) that ConfigParser and SafeConfigParser try to interpolate.