### PR TITLE
Used shared clones of the master repo to reduce disk usage

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -29,6 +29,7 @@ class MasterCheckout(object):
         os.rename(os.path.join(path, "tmp", ".git"), os.path.join(path, ".git"))
         git("reset", "--hard", "HEAD", cwd=path)
         git("config", "--add", "remote.origin.fetch", "+refs/pull/*/head:refs/remotes/origin/pr/*", cwd=path)
+        git("config", "gc.auto", "0", cwd=path)
         git("fetch", "origin", cwd=path)
         git("submodule", "init", cwd=path)
         git("submodule", "update", "--recursive", cwd=path)
@@ -60,7 +61,7 @@ class PullRequestCheckout(object):
         rv = cls(path, number)
         if not os.path.exists(path):
             os.mkdir(path)
-            git("clone", "--no-checkout", base_path, path, cwd=path)
+            git("clone", "--shared", "--no-checkout", base_path, path, cwd=path)
             git("submodule", "init", cwd=path)
             git("config", "--add", "remote.origin.fetch", "+refs/remotes/origin/pr/*:refs/pr/*", cwd=path)
         elif not PullRequestCheckout.exists(base_path, number):


### PR DESCRIPTION
The master repo should be changed to have `gc.auto 0` before this is landed.

From the man page:

> NOTE: this is a possibly dangerous operation; do not use it unless you
           understand what it does. If you clone your repository using this option and
           then delete branches (or use any other Git command that makes any existing
           commit unreferenced) in the source repository, some objects may become
           unreferenced (or dangling). These objects may be removed by normal Git
           operations (such as git commit) which automatically call git gc --auto. (See
           git-gc(1).) If these objects are removed and were referenced by the cloned
           repository, then the cloned repository will become corrupt.